### PR TITLE
Open vvvvolders feature

### DIFF
--- a/Patchbox (VVVV).v4p
+++ b/Patchbox (VVVV).v4p
@@ -1,6 +1,6 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50alpha35.5.dtd" >
-   <PATCH nodename="C:\dev\vvvv\vvvv-Patchbox\Patchbox (VVVV).v4p" scrollx="0" scrolly="1860" systemname="Patchbox (VVVV)" filename="C:\dev\vvvv\vvvv-Patchbox\Patchbox (VVVV).v4p">
-   <BOUNDS type="Window" left="1920" top="1905" width="12105" height="12585">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.5.dtd" >
+   <PATCH nodename="D:\Documents\dev\vvvv-Patchbox\Patchbox (VVVV).v4p" scrollx="0" scrolly="4007" systemname="Patchbox (VVVV)" filename="C:\dev\vvvv\vvvv-Patchbox\Patchbox (VVVV).v4p">
+   <BOUNDS type="Window" left="6818" top="1008" width="12103" height="12579">
    </BOUNDS>
    <PACK Name="addonpack" Version="35.0.0">
    </PACK>
@@ -19,9 +19,9 @@
    </PIN>
    </NODE>
    <NODE nodename="Operandomatic (VVVV)" componentmode="Hidden" id="0" systemname="Operandomatic (VVVV)" filename="modules\Operandomatic (VVVV).v4p" stayontop="0">
-   <BOUNDS type="Node" left="6270" top="5535" width="100" height="100">
+   <BOUNDS type="Node" left="6270" top="4765" width="100" height="100">
    </BOUNDS>
-   <BOUNDS type="Box" left="6270" top="5535" width="0" height="0">
+   <BOUNDS type="Box" left="6270" top="4765" width="0" height="0">
    </BOUNDS>
    <BOUNDS type="Window" left="1836" top="696" width="18816" height="11232">
    </BOUNDS>
@@ -43,15 +43,15 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="0" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2960" y="4658">
+   <LINKPOINT x="2960" y="4405">
    </LINKPOINT>
-   <LINKPOINT x="6265" y="4658">
+   <LINKPOINT x="6265" y="4141">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="16" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7515" top="5010" width="480" height="480">
+   <BOUNDS type="Box" left="7515" top="4240" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="7515" top="5010" width="0" height="0">
+   <BOUNDS type="Node" left="7515" top="4240" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -71,9 +71,9 @@
    <LINK srcnodeid="16" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Enable">
    </LINK>
    <NODE systemname="ChangePatch (VVVV XElement)" filename="modules\Common\ChangePatch (VVVV XElement).v4p" nodename="ChangePatch (VVVV XElement)" componentmode="Hidden" id="10">
-   <BOUNDS type="Node" left="2892" top="13113" width="3990" height="270">
+   <BOUNDS type="Node" left="2892" top="13883" width="3990" height="270">
    </BOUNDS>
-   <BOUNDS type="Box" left="2892" top="13113" width="8319" height="5556">
+   <BOUNDS type="Box" left="2892" top="13883" width="8319" height="5556">
    </BOUNDS>
    <BOUNDS type="Window" left="11604" top="1020" width="8304" height="8760">
    </BOUNDS>
@@ -89,17 +89,17 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="10" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2915" y="8160">
+   <LINKPOINT x="2915" y="8413">
    </LINKPOINT>
-   <LINKPOINT x="2920" y="8760">
+   <LINKPOINT x="2920" y="9277">
    </LINKPOINT>
    </LINK>
    <NODE systemname="IOMagic (VVVV)" filename="modules\IOMagic (VVVV).v4p" nodename="IOMagic (VVVV)" componentmode="Hidden" id="18">
-   <BOUNDS type="Node" left="8370" top="5535" width="1725" height="270">
+   <BOUNDS type="Node" left="8370" top="4765" width="1725" height="270">
    </BOUNDS>
    <PIN pinname="Patch" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="8370" top="5535">
+   <BOUNDS type="Box" left="8370" top="4765">
    </BOUNDS>
    <PIN pinname="Node Changes" visible="1" slicecount="1" values="||">
    </PIN>
@@ -113,11 +113,11 @@
    </PIN>
    </NODE>
    <NODE systemname="Commander (VVVV)" filename="modules\Commander (VVVV).v4p" nodename="Commander (VVVV)" componentmode="Hidden" id="19">
-   <BOUNDS type="Node" left="8325" top="9075" width="100" height="100">
+   <BOUNDS type="Node" left="8325" top="8445" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Patch" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="8325" top="9075">
+   <BOUNDS type="Box" left="8325" top="8445">
    </BOUNDS>
    <PIN pinname="Patch Window Change" visible="1">
    </PIN>
@@ -129,21 +129,21 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="18" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2960" y="4658">
+   <LINKPOINT x="2960" y="4405">
    </LINKPOINT>
-   <LINKPOINT x="8365" y="4658">
+   <LINKPOINT x="8365" y="4141">
    </LINKPOINT>
    </LINK>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="19" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2930" y="8175">
+   <LINKPOINT x="2930" y="7968">
    </LINKPOINT>
-   <LINKPOINT x="9415" y="8175">
+   <LINKPOINT x="9415" y="7752">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="21" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="10035" top="5010" width="480" height="480">
+   <BOUNDS type="Box" left="10035" top="4240" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="10035" top="5010" width="0" height="0">
+   <BOUNDS type="Node" left="10035" top="4240" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -163,9 +163,9 @@
    <LINK srcnodeid="21" srcpinname="Y Output Value" dstnodeid="18" dstpinname="Enable">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="22" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="9390" top="8580" width="480" height="480">
+   <BOUNDS type="Box" left="9390" top="7950" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="9390" top="8580" width="0" height="0">
+   <BOUNDS type="Node" left="9390" top="7950" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -185,9 +185,9 @@
    <LINK srcnodeid="22" srcpinname="Y Output Value" dstnodeid="19" dstpinname="Enable">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="23" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="5520" top="12285" width="480" height="480">
+   <BOUNDS type="Box" left="5520" top="13055" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="5520" top="12285" width="0" height="0">
+   <BOUNDS type="Node" left="5520" top="13055" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
    </PIN>
@@ -205,9 +205,9 @@
    <LINK srcnodeid="23" srcpinname="Y Output Value" dstnodeid="10" dstpinname="Add to UNDO history">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="24" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="6840" top="12510" width="480" height="480">
+   <BOUNDS type="Box" left="6840" top="13280" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="6840" top="12510" width="0" height="0">
+   <BOUNDS type="Node" left="6840" top="13280" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
    </PIN>
@@ -225,11 +225,11 @@
    <LINK srcnodeid="24" srcpinname="Y Output Value" dstnodeid="10" dstpinname="Mark Patch as Changed" linkstyle="PolyLine">
    </LINK>
    <NODE systemname="IOScaler (VVVV)" filename="modules\IOScaler (VVVV).v4p" nodename="IOScaler (VVVV)" componentmode="Hidden" id="25">
-   <BOUNDS type="Node" left="6270" top="7155" width="1530" height="270">
+   <BOUNDS type="Node" left="6270" top="6665" width="1530" height="270">
    </BOUNDS>
    <PIN pinname="Patch" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="6270" top="7155">
+   <BOUNDS type="Box" left="6270" top="6665">
    </BOUNDS>
    <PIN pinname="Changed Nodes" visible="1">
    </PIN>
@@ -245,15 +245,15 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="25" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2925" y="6465">
+   <LINKPOINT x="2925" y="6304">
    </LINKPOINT>
-   <LINKPOINT x="6300" y="6465">
+   <LINKPOINT x="6300" y="6136">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="26" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7737" top="6555" width="480" height="480">
+   <BOUNDS type="Box" left="7737" top="6065" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="7737" top="6555" width="0" height="0">
+   <BOUNDS type="Node" left="7737" top="6065" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -273,11 +273,11 @@
    <LINK srcnodeid="26" srcpinname="Y Output Value" dstnodeid="25" dstpinname="Enable">
    </LINK>
    <NODE systemname="SnapToGrid (VVVV)" filename="modules\SnapToGrid (VVVV).v4p" nodename="..\..\..\dev\vvvv\vvvv-Patchbox\modules\SnapToGrid (VVVV).v4p" componentmode="Hidden" id="27">
-   <BOUNDS type="Node" left="6285" top="9075" width="100" height="100">
+   <BOUNDS type="Node" left="6271" top="8445" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Node Changes" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="6285" top="9075">
+   <BOUNDS type="Box" left="6271" top="8445">
    </BOUNDS>
    <PIN pinname="Patch" visible="1">
    </PIN>
@@ -287,15 +287,15 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="27" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2930" y="8175">
+   <LINKPOINT x="2926" y="7968">
    </LINKPOINT>
-   <LINKPOINT x="6310" y="8175">
+   <LINKPOINT x="6300" y="7752">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="28" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7305" top="8595" width="480" height="480">
+   <BOUNDS type="Box" left="7291" top="7965" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="7305" top="8595" width="0" height="0">
+   <BOUNDS type="Node" left="7291" top="7965" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -315,11 +315,11 @@
    <LINK srcnodeid="28" srcpinname="Y Output Value" dstnodeid="27" dstpinname="Enable">
    </LINK>
    <NODE systemname="CreatePatchlet (VVVV)" filename="modules\CreatePatchlet (VVVV).v4p" nodename="CreatePatchlet (VVVV)" componentmode="Hidden" id="30">
-   <BOUNDS type="Node" left="4215" top="5535" width="1545" height="270">
+   <BOUNDS type="Node" left="4215" top="4765" width="1545" height="270">
    </BOUNDS>
    <PIN pinname="Node Changes" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="4215" top="5535">
+   <BOUNDS type="Box" left="4215" top="4765">
    </BOUNDS>
    <PIN pinname="Patch" visible="1">
    </PIN>
@@ -333,15 +333,15 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="30" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2960" y="4665">
+   <LINKPOINT x="2960" y="4412">
    </LINKPOINT>
-   <LINKPOINT x="4210" y="4665">
+   <LINKPOINT x="4210" y="4148">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="31" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="5718" top="5043" width="480" height="480">
+   <BOUNDS type="Box" left="5718" top="4273" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="5718" top="5043" width="0" height="0">
+   <BOUNDS type="Node" left="5718" top="4273" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -361,9 +361,9 @@
    <LINK srcnodeid="31" srcpinname="Y Output Value" dstnodeid="30" dstpinname="Enable">
    </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="32" systemname="IOBox (String)">
-   <BOUNDS type="Box" left="4341" top="5049" width="975" height="300">
+   <BOUNDS type="Box" left="4341" top="4279" width="975" height="300">
    </BOUNDS>
-   <BOUNDS type="Node" left="4341" top="5049" width="0" height="0">
+   <BOUNDS type="Node" left="4341" top="4279" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Input String" slicecount="1" visible="1" values="Patchlet">
    </PIN>
@@ -381,7 +381,7 @@
    <LINK srcnodeid="32" srcpinname="Output String" dstnodeid="30" dstpinname="Patchlet Directory">
    </LINK>
    <NODE systemname="IOType (VVVV)" filename="modules\IOType (VVVV).v4p" nodename="IOType (VVVV)" componentmode="Hidden" id="33">
-   <BOUNDS type="Node" left="8370" top="7155" width="100" height="100">
+   <BOUNDS type="Node" left="8370" top="6665" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Patch" visible="1">
    </PIN>
@@ -389,21 +389,21 @@
    </PIN>
    <PIN pinname="Enabled" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="8370" top="7155">
+   <BOUNDS type="Box" left="8370" top="6665">
    </BOUNDS>
    <PIN pinname="Evaluate" visible="1" pintype="Input" slicecount="1" values="1">
    </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="33" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2930" y="6465">
+   <LINKPOINT x="2930" y="6304">
    </LINKPOINT>
-   <LINKPOINT x="8395" y="6465">
+   <LINKPOINT x="8395" y="6136">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="34" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="9096" top="6669" width="480" height="480">
+   <BOUNDS type="Box" left="9096" top="6179" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="9096" top="6669" width="0" height="0">
+   <BOUNDS type="Node" left="9096" top="6179" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -423,7 +423,7 @@
    <LINK srcnodeid="34" srcpinname="Y Output Value" dstnodeid="33" dstpinname="Enabled">
    </LINK>
    <NODE systemname="Zip (XElement Bin)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Zip (XElement Bin)" componentmode="Hidden" id="35" hiddenwhenlocked="1">
-   <BOUNDS type="Node" left="4200" top="6090" width="5265" height="270">
+   <BOUNDS type="Node" left="4200" top="5320" width="5265" height="270">
    </BOUNDS>
    <PIN pinname="Input Count" slicecount="1" values="3">
    </PIN>
@@ -453,7 +453,7 @@
    <LINK srcnodeid="18" srcpinname="Node Changes" dstnodeid="35" dstpinname="Input 3">
    </LINK>
    <NODE systemname="Zip (XElement Bin)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Zip (XElement Bin)" componentmode="Hidden" id="36" hiddenwhenlocked="1">
-   <BOUNDS type="Node" left="4200" top="7710" width="5280" height="270">
+   <BOUNDS type="Node" left="4200" top="7220" width="5280" height="270">
    </BOUNDS>
    <PIN pinname="Input Count" slicecount="1" values="3">
    </PIN>
@@ -483,7 +483,7 @@
    <LINK srcnodeid="33" srcpinname="Node Changes" dstnodeid="36" dstpinname="Input 3">
    </LINK>
    <NODE systemname="Zip (XElement Bin)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Zip (XElement Bin)" componentmode="Hidden" id="37" hiddenwhenlocked="1">
-   <BOUNDS type="Node" left="4200" top="9630" width="5220" height="270">
+   <BOUNDS type="Node" left="4200" top="9000" width="5220" height="270">
    </BOUNDS>
    <PIN pinname="Input Count" slicecount="1" values="3">
    </PIN>
@@ -513,9 +513,9 @@
    <LINK srcnodeid="36" srcpinname="Output" dstnodeid="37" dstpinname="Input 1" hiddenwhenlocked="1">
    </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="38" systemname="IOBox (String)">
-   <BOUNDS type="Node" left="945" top="5475" width="8205" height="270">
+   <BOUNDS type="Node" left="945" top="4704" width="8205" height="270">
    </BOUNDS>
-   <BOUNDS type="Box" left="945" top="5475" width="3000" height="780">
+   <BOUNDS type="Box" left="945" top="4704" width="3000" height="780">
    </BOUNDS>
    <PIN pinname="Input String" visible="0" slicecount="1" values="|these patches make use of a fresh comment box. Type certain commands to trigger specific node creation makros|">
    </PIN>
@@ -527,9 +527,9 @@
    </PIN>
    </NODE>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="39" systemname="IOBox (String)">
-   <BOUNDS type="Node" left="945" top="6930" width="8205" height="270">
+   <BOUNDS type="Node" left="945" top="6440" width="8205" height="270">
    </BOUNDS>
-   <BOUNDS type="Box" left="945" top="6930" width="3015" height="1005">
+   <BOUNDS type="Box" left="945" top="6440" width="3015" height="1005">
    </BOUNDS>
    <PIN pinname="Input String" visible="0" slicecount="1" values="|these patches allow direct iobox manipulation while scaling/moving them. they listen keystrokes, mousewheel and right mousebutton|">
    </PIN>
@@ -541,9 +541,9 @@
    </PIN>
    </NODE>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="40" systemname="IOBox (String)">
-   <BOUNDS type="Node" left="945" top="9045" width="8205" height="270">
+   <BOUNDS type="Node" left="945" top="8414" width="8205" height="270">
    </BOUNDS>
-   <BOUNDS type="Box" left="945" top="9045" width="3015" height="1005">
+   <BOUNDS type="Box" left="945" top="8414" width="3015" height="1005">
    </BOUNDS>
    <PIN pinname="Input String" visible="0" slicecount="1" values="|these patches allow broader manipulation of your patch window. move it around or enforce a grid upon it.|">
    </PIN>
@@ -583,9 +583,9 @@
    <LINK srcnodeid="28" srcpinname="Y Output Value" dstnodeid="27" dstpinname="Evaluate">
    </LINK>
    <NODE nodename="IOBox (Node)" componentmode="InABox" id="43" systemname="IOBox (Node)">
-   <BOUNDS type="Box" left="4200" top="12630" width="300" height="285">
+   <BOUNDS type="Box" left="4200" top="13400" width="300" height="285">
    </BOUNDS>
-   <BOUNDS type="Node" left="4200" top="12630" width="0" height="0">
+   <BOUNDS type="Node" left="4200" top="13400" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Output Node" visible="1">
    </PIN>
@@ -595,7 +595,7 @@
    <LINK srcnodeid="43" srcpinname="Output Node" dstnodeid="10" dstpinname="Patch Changes">
    </LINK>
    <NODE systemname="ChangeIOCount (VVVV)" filename="modules\ChangeIOCount (VVVV).v4p" nodename="ChangeIOCount (VVVV)" componentmode="InAWindow" id="44">
-   <BOUNDS type="Node" left="6240" top="10560" width="100" height="100">
+   <BOUNDS type="Node" left="6254" top="10000" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Node Changes" visible="1">
    </PIN>
@@ -605,7 +605,7 @@
    </PIN>
    </NODE>
    <NODE systemname="Zip (XElement Bin)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Zip (XElement Bin)" componentmode="Hidden" id="45" hiddenwhenlocked="1">
-   <BOUNDS type="Node" left="4185" top="11220" width="5220" height="270">
+   <BOUNDS type="Node" left="4185" top="10660" width="5220" height="270">
    </BOUNDS>
    <PIN pinname="Input Count" slicecount="1" values="3">
    </PIN>
@@ -628,16 +628,14 @@
    <PIN pinname="Descriptive Name" slicecount="1" values="|Patching Behaviour|">
    </PIN>
    </NODE>
-   <LINK srcnodeid="37" srcpinname="Output" dstnodeid="45" dstpinname="Input 1">
-   </LINK>
-   <LINK srcnodeid="45" srcpinname="Output" dstnodeid="43" dstpinname="Input Node">
+   <LINK srcnodeid="37" srcpinname="Output" dstnodeid="45" dstpinname="Input 1" hiddenwhenlocked="1">
    </LINK>
    <LINK srcnodeid="44" srcpinname="Node Changes" dstnodeid="45" dstpinname="Input 2">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="46" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7455" top="10005" width="480" height="480">
+   <BOUNDS type="Box" left="7553" top="9403" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="7455" top="10005" width="0" height="0">
+   <BOUNDS type="Node" left="7553" top="9403" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -653,15 +651,15 @@
    <LINK srcnodeid="46" srcpinname="Y Output Value" dstnodeid="44" dstpinname="Enabled">
    </LINK>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="44" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2925" y="10320">
+   <LINKPOINT x="2929" y="10136">
    </LINKPOINT>
-   <LINKPOINT x="6270" y="10320">
+   <LINKPOINT x="6280" y="9944">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="47" systemname="IOBox (String)">
-   <BOUNDS type="Node" left="855" top="10845" width="8205" height="270">
+   <BOUNDS type="Node" left="945" top="10283" width="8205" height="270">
    </BOUNDS>
-   <BOUNDS type="Box" left="855" top="10845" width="3015" height="1005">
+   <BOUNDS type="Box" left="945" top="10283" width="3015" height="1005">
    </BOUNDS>
    <PIN pinname="Input String" visible="0" slicecount="1" values="|these patches allow rapid configuration of nodes, e.g. pin count etc.|">
    </PIN>
@@ -674,4 +672,54 @@
    </NODE>
    <PACK Name="vvvv-Message" Version="2.9.8">
    </PACK>
+   <NODE systemname="Zip (XElement Bin)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Zip (XElement Bin)" componentmode="Hidden" id="48" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="4192" top="12319" width="5220" height="270">
+   </BOUNDS>
+   <PIN pinname="Input Count" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Input 1" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Input 2" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Input 3" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 4" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Input 5" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Input 6" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Input 7" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|VVVV Utils|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="45" srcpinname="Output" dstnodeid="48" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="48" srcpinname="Output" dstnodeid="43" dstpinname="Input Node">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="49" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="945" top="11956" width="8205" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="945" top="11956" width="3015" height="1005">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|these patches provide some general vvvv features, not directly related to patching.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE systemname="ShowV4Folders (VVVV)" filename="modules\ShowV4Folders (VVVV).v4p" componentmode="Hidden" id="50" nodename="modules\ShowV4Folders (VVVV).v4p">
+   <BOUNDS type="Node" left="5509" top="11256" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="5509" top="11256" width="4800" height="3600">
+   </BOUNDS>
+   <BOUNDS type="Window" left="11613" top="4536" width="8995" height="5999">
+   </BOUNDS>
+   </NODE>
    </PATCH>

--- a/Patchbox (VVVV).v4p
+++ b/Patchbox (VVVV).v4p
@@ -689,9 +689,9 @@
    <LINK srcnodeid="45" srcpinname="Output" dstnodeid="43" dstpinname="Input Node">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="66" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7546" top="11144" width="480" height="480">
+   <BOUNDS type="Box" left="9016" top="11264" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="7546" top="11144" width="0" height="0">
+   <BOUNDS type="Node" left="9016" top="11264" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -706,12 +706,12 @@
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
    </NODE>
-   <NODE systemname="ShowV4Folders (VVVV)" filename="modules\ShowV4Folders (VVVV).v4p" componentmode="Hidden" id="50" nodename="ShowV4Folders (VVVV)">
-   <BOUNDS type="Node" left="6293" top="11767" width="100" height="100">
+   <NODE systemname="ShowV4Folders (VVVV)" filename="modules\ShowV4Folders (VVVV).v4p" componentmode="InAWindow" id="50" nodename="ShowV4Folders (VVVV)">
+   <BOUNDS type="Node" left="6308" top="12022" width="100" height="100">
    </BOUNDS>
-   <BOUNDS type="Box" left="6293" top="11767" width="4800" height="3600">
+   <BOUNDS type="Box" left="6308" top="12022" width="4800" height="3600">
    </BOUNDS>
-   <BOUNDS type="Window" left="2758" top="2625" width="8995" height="7280">
+   <BOUNDS type="Window" left="2745" top="2625" width="9615" height="7905">
    </BOUNDS>
    <PIN pinname="Enabled" slicecount="1" visible="1" values="1">
    </PIN>
@@ -719,15 +719,49 @@
    </PIN>
    <PIN pinname="Evaluate" visible="1" pintype="Input" slicecount="1" values="1">
    </PIN>
+   <PIN pinname="Custom Directories" visible="1">
+   </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="50" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2921" y="11452">
+   <LINKPOINT x="2925" y="11670">
    </LINKPOINT>
-   <LINKPOINT x="6319" y="11452">
+   <LINKPOINT x="6345" y="11670">
    </LINKPOINT>
    </LINK>
-   <LINK srcnodeid="66" srcpinname="Y Output Value" dstnodeid="50" dstpinname="Enabled">
+   <LINK srcnodeid="66" srcpinname="Y Output Value" dstnodeid="50" dstpinname="Enabled" linkstyle="VHV">
+   <LINKPOINT x="9015" y="11865">
+   </LINKPOINT>
+   <LINKPOINT x="7215" y="11865">
+   </LINKPOINT>
    </LINK>
-   <LINK srcnodeid="66" srcpinname="Y Output Value" dstnodeid="50" dstpinname="Evaluate">
+   <LINK srcnodeid="66" srcpinname="Y Output Value" dstnodeid="50" dstpinname="Evaluate" linkstyle="VHV">
+   <LINKPOINT x="9015" y="11865">
+   </LINKPOINT>
+   <LINKPOINT x="7650" y="11865">
+   </LINKPOINT>
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="67" systemname="IOBox (String)">
+   <BOUNDS type="Box" left="6735" top="11265" width="2175" height="495">
+   </BOUNDS>
+   <BOUNDS type="Node" left="6735" top="11265" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="2" visible="1" values="c:\temp,c:\dev\vvvv\vvvv-sdk">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="Directory">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="67" srcpinname="Output String" dstnodeid="50" dstpinname="Custom Directories">
    </LINK>
    </PATCH>

--- a/Patchbox (VVVV).v4p
+++ b/Patchbox (VVVV).v4p
@@ -1,5 +1,5 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.5.dtd" >
-   <PATCH nodename="D:\Documents\dev\vvvv-Patchbox\Patchbox (VVVV).v4p" scrollx="0" scrolly="4007" systemname="Patchbox (VVVV)" filename="C:\dev\vvvv\vvvv-Patchbox\Patchbox (VVVV).v4p">
+   <PATCH nodename="D:\Documents\dev\vvvv-Patchbox\Patchbox (VVVV).v4p" scrollx="0" scrolly="2246" systemname="Patchbox (VVVV)" filename="C:\dev\vvvv\vvvv-Patchbox\Patchbox (VVVV).v4p">
    <BOUNDS type="Window" left="6818" top="1008" width="12103" height="12579">
    </BOUNDS>
    <PACK Name="addonpack" Version="35.0.0">
@@ -7,7 +7,7 @@
    <NODE nodename="IOBox (String)" componentmode="InABox" id="2" systemname="IOBox (String)">
    <BOUNDS type="Node" left="945" top="1500" width="5100" height="600">
    </BOUNDS>
-   <BOUNDS type="Box" left="945" top="1500" width="5160" height="1725">
+   <BOUNDS type="Box" left="945" top="1500" width="5201" height="1722">
    </BOUNDS>
    <PIN pinname="Input String" slicecount="1" visible="0" values="|Add this Module to your root.v4p (use Alt + R to access it) and save it.&cr;&lf;&cr;&lf;You can enable or disable various patching helpers in this patch, depending on your needs and performance considerations.&cr;&lf;&cr;&lf;Tested with beta33.7 and beta 34.x&cr;&lf;&cr;&lf;Feel free to extend!|">
    </PIN>
@@ -19,9 +19,9 @@
    </PIN>
    </NODE>
    <NODE nodename="Operandomatic (VVVV)" componentmode="Hidden" id="0" systemname="Operandomatic (VVVV)" filename="modules\Operandomatic (VVVV).v4p" stayontop="0">
-   <BOUNDS type="Node" left="6270" top="4765" width="100" height="100">
+   <BOUNDS type="Node" left="6277" top="4765" width="100" height="100">
    </BOUNDS>
-   <BOUNDS type="Box" left="6270" top="4765" width="0" height="0">
+   <BOUNDS type="Box" left="6277" top="4765" width="0" height="0">
    </BOUNDS>
    <BOUNDS type="Window" left="1836" top="696" width="18816" height="11232">
    </BOUNDS>
@@ -43,15 +43,15 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="0" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2960" y="4405">
+   <LINKPOINT x="2962" y="4405">
    </LINKPOINT>
-   <LINKPOINT x="6265" y="4141">
+   <LINKPOINT x="6270" y="4141">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="16" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7515" top="4240" width="480" height="480">
+   <BOUNDS type="Box" left="7522" top="4240" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="7515" top="4240" width="0" height="0">
+   <BOUNDS type="Node" left="7522" top="4240" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -315,11 +315,11 @@
    <LINK srcnodeid="28" srcpinname="Y Output Value" dstnodeid="27" dstpinname="Enable">
    </LINK>
    <NODE systemname="CreatePatchlet (VVVV)" filename="modules\CreatePatchlet (VVVV).v4p" nodename="CreatePatchlet (VVVV)" componentmode="Hidden" id="30">
-   <BOUNDS type="Node" left="4215" top="4765" width="1545" height="270">
+   <BOUNDS type="Node" left="4208" top="4765" width="1545" height="270">
    </BOUNDS>
    <PIN pinname="Node Changes" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="4215" top="4765">
+   <BOUNDS type="Box" left="4208" top="4765">
    </BOUNDS>
    <PIN pinname="Patch" visible="1">
    </PIN>
@@ -333,15 +333,15 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="30" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2960" y="4412">
+   <LINKPOINT x="2958" y="4412">
    </LINKPOINT>
-   <LINKPOINT x="4210" y="4148">
+   <LINKPOINT x="4205" y="4148">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="31" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="5718" top="4273" width="480" height="480">
+   <BOUNDS type="Box" left="5711" top="4273" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="5718" top="4273" width="0" height="0">
+   <BOUNDS type="Node" left="5711" top="4273" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -361,9 +361,9 @@
    <LINK srcnodeid="31" srcpinname="Y Output Value" dstnodeid="30" dstpinname="Enable">
    </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="32" systemname="IOBox (String)">
-   <BOUNDS type="Box" left="4341" top="4279" width="975" height="300">
+   <BOUNDS type="Box" left="4334" top="4279" width="975" height="300">
    </BOUNDS>
-   <BOUNDS type="Node" left="4341" top="4279" width="0" height="0">
+   <BOUNDS type="Node" left="4334" top="4279" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Input String" slicecount="1" visible="1" values="Patchlet">
    </PIN>
@@ -589,13 +589,13 @@
    </BOUNDS>
    <PIN pinname="Output Node" visible="1">
    </PIN>
-   <PIN pinname="Input Node" visible="1">
+   <PIN pinname="Input Node" visible="1" slicecount="1" values="||">
    </PIN>
    </NODE>
    <LINK srcnodeid="43" srcpinname="Output Node" dstnodeid="10" dstpinname="Patch Changes">
    </LINK>
-   <NODE systemname="ChangeIOCount (VVVV)" filename="modules\ChangeIOCount (VVVV).v4p" nodename="ChangeIOCount (VVVV)" componentmode="InAWindow" id="44">
-   <BOUNDS type="Node" left="6254" top="10000" width="100" height="100">
+   <NODE systemname="ChangeIOCount (VVVV)" filename="modules\ChangeIOCount (VVVV).v4p" nodename="ChangeIOCount (VVVV)" componentmode="Hidden" id="44">
+   <BOUNDS type="Node" left="6261" top="10000" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Node Changes" visible="1">
    </PIN>
@@ -605,7 +605,7 @@
    </PIN>
    </NODE>
    <NODE systemname="Zip (XElement Bin)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Zip (XElement Bin)" componentmode="Hidden" id="45" hiddenwhenlocked="1">
-   <BOUNDS type="Node" left="4185" top="10660" width="5220" height="270">
+   <BOUNDS type="Node" left="4192" top="10660" width="5220" height="270">
    </BOUNDS>
    <PIN pinname="Input Count" slicecount="1" values="3">
    </PIN>
@@ -633,9 +633,9 @@
    <LINK srcnodeid="44" srcpinname="Node Changes" dstnodeid="45" dstpinname="Input 2">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="46" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7553" top="9403" width="480" height="480">
+   <BOUNDS type="Box" left="7560" top="9403" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="7553" top="9403" width="0" height="0">
+   <BOUNDS type="Node" left="7560" top="9403" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -651,9 +651,9 @@
    <LINK srcnodeid="46" srcpinname="Y Output Value" dstnodeid="44" dstpinname="Enabled">
    </LINK>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="44" dstpinname="Patch" linkstyle="VHV">
-   <LINKPOINT x="2929" y="10136">
+   <LINKPOINT x="2931" y="10136">
    </LINKPOINT>
-   <LINKPOINT x="6280" y="9944">
+   <LINKPOINT x="6285" y="9944">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="47" systemname="IOBox (String)">
@@ -672,38 +672,10 @@
    </NODE>
    <PACK Name="vvvv-Message" Version="2.9.8">
    </PACK>
-   <NODE systemname="Zip (XElement Bin)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Zip (XElement Bin)" componentmode="Hidden" id="48" hiddenwhenlocked="1">
-   <BOUNDS type="Node" left="4192" top="12319" width="5220" height="270">
-   </BOUNDS>
-   <PIN pinname="Input Count" slicecount="1" values="3">
-   </PIN>
-   <PIN pinname="Input 1" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Input 2" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Input 3" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   <PIN pinname="Input 4" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Input 5" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Input 6" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Input 7" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Descriptive Name" slicecount="1" values="|VVVV Utils|">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="45" srcpinname="Output" dstnodeid="48" dstpinname="Input 1">
-   </LINK>
-   <LINK srcnodeid="48" srcpinname="Output" dstnodeid="43" dstpinname="Input Node">
-   </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="49" systemname="IOBox (String)">
-   <BOUNDS type="Node" left="945" top="11956" width="8205" height="270">
+   <BOUNDS type="Node" left="945" top="11816" width="8205" height="270">
    </BOUNDS>
-   <BOUNDS type="Box" left="945" top="11956" width="3015" height="1005">
+   <BOUNDS type="Box" left="945" top="11816" width="3015" height="1005">
    </BOUNDS>
    <PIN pinname="Input String" visible="0" slicecount="1" values="|these patches provide some general vvvv features, not directly related to patching.|">
    </PIN>
@@ -714,12 +686,42 @@
    <PIN pinname="String Type" slicecount="1" values="MultiLine">
    </PIN>
    </NODE>
-   <NODE systemname="ShowV4Folders (VVVV)" filename="modules\ShowV4Folders (VVVV).v4p" componentmode="Hidden" id="50" nodename="modules\ShowV4Folders (VVVV).v4p">
-   <BOUNDS type="Node" left="5509" top="11256" width="100" height="100">
+   <LINK srcnodeid="45" srcpinname="Output" dstnodeid="43" dstpinname="Input Node">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="66" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="7546" top="11144" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Box" left="5509" top="11256" width="4800" height="3600">
+   <BOUNDS type="Node" left="7546" top="11144" width="0" height="0">
    </BOUNDS>
-   <BOUNDS type="Window" left="11613" top="4536" width="8995" height="5999">
-   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
    </NODE>
+   <NODE systemname="ShowV4Folders (VVVV)" filename="modules\ShowV4Folders (VVVV).v4p" componentmode="Hidden" id="50" nodename="ShowV4Folders (VVVV)">
+   <BOUNDS type="Node" left="6293" top="11767" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="6293" top="11767" width="4800" height="3600">
+   </BOUNDS>
+   <BOUNDS type="Window" left="2758" top="2625" width="8995" height="7280">
+   </BOUNDS>
+   <PIN pinname="Enabled" slicecount="1" visible="1" values="1">
+   </PIN>
+   <PIN pinname="Patch" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="50" dstpinname="Patch" linkstyle="VHV">
+   <LINKPOINT x="2921" y="11452">
+   </LINKPOINT>
+   <LINKPOINT x="6319" y="11452">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="66" srcpinname="Y Output Value" dstnodeid="50" dstpinname="Enabled">
+   </LINK>
    </PATCH>

--- a/Patchbox (VVVV).v4p
+++ b/Patchbox (VVVV).v4p
@@ -1,5 +1,5 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.5.dtd" >
-   <PATCH nodename="D:\Documents\dev\vvvv-Patchbox\Patchbox (VVVV).v4p" scrollx="0" scrolly="2246" systemname="Patchbox (VVVV)" filename="C:\dev\vvvv\vvvv-Patchbox\Patchbox (VVVV).v4p">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50alpha35.5.dtd" >
+   <PATCH nodename="C:\dev\vvvv\vvvv-Patchbox\Patchbox (VVVV).v4p" scrollx="0" scrolly="3480" systemname="Patchbox (VVVV)" filename="C:\dev\vvvv\vvvv-Patchbox\Patchbox (VVVV).v4p">
    <BOUNDS type="Window" left="6818" top="1008" width="12103" height="12579">
    </BOUNDS>
    <PACK Name="addonpack" Version="35.0.0">
@@ -703,6 +703,8 @@
    </PIN>
    <PIN pinname="Behavior" slicecount="1" values="Toggle">
    </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
    </NODE>
    <NODE systemname="ShowV4Folders (VVVV)" filename="modules\ShowV4Folders (VVVV).v4p" componentmode="Hidden" id="50" nodename="ShowV4Folders (VVVV)">
    <BOUNDS type="Node" left="6293" top="11767" width="100" height="100">
@@ -715,6 +717,8 @@
    </PIN>
    <PIN pinname="Patch" visible="1">
    </PIN>
+   <PIN pinname="Evaluate" visible="1" pintype="Input" slicecount="1" values="1">
+   </PIN>
    </NODE>
    <LINK srcnodeid="5" srcpinname="Patch" dstnodeid="50" dstpinname="Patch" linkstyle="VHV">
    <LINKPOINT x="2921" y="11452">
@@ -723,5 +727,7 @@
    </LINKPOINT>
    </LINK>
    <LINK srcnodeid="66" srcpinname="Y Output Value" dstnodeid="50" dstpinname="Enabled">
+   </LINK>
+   <LINK srcnodeid="66" srcpinname="Y Output Value" dstnodeid="50" dstpinname="Evaluate">
    </LINK>
    </PATCH>

--- a/modules/ChangeIOCount (VVVV).v4p
+++ b/modules/ChangeIOCount (VVVV).v4p
@@ -1,5 +1,5 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.5.dtd" >
-   <PATCH nodename="D:\Documents\dev\vvvv-Patchbox\modules\ChangeIOCount (VVVV).v4p" systemname="ChangeIOCount (VVVV)" filename="D:\Documents\dev\vvvv-Patchbox\modules\ChangeIOCount (VVVV).v4p" scrollx="35" scrolly="-360">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50alpha35.5.dtd" >
+   <PATCH nodename="C:\dev\vvvv\vvvv-Patchbox\modules\ChangeIOCount (VVVV).v4p" systemname="ChangeIOCount (VVVV)" filename="D:\Documents\dev\vvvv-Patchbox\modules\ChangeIOCount (VVVV).v4p" scrollx="35" scrolly="-360">
    <BOUNDS type="Window" left="1463" top="490" width="8666" height="8729">
    </BOUNDS>
    <PACK Name="addonpack" Version="35.0.0">
@@ -257,9 +257,9 @@
    </PIN>
    </NODE>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="114" systemname="IOBox (String)">
-   <BOUNDS type="Box" left="5299" top="4620" width="903" height="371">
+   <BOUNDS type="Box" left="5299" top="4260" width="855" height="630">
    </BOUNDS>
-   <BOUNDS type="Node" left="5299" top="4620" width="0" height="0">
+   <BOUNDS type="Node" left="5299" top="4260" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Input String" slicecount="2" visible="1" values="Unzip,Output">
    </PIN>
@@ -295,11 +295,11 @@
    <LINK srcnodeid="110" srcpinname="Node Name" dstnodeid="116" dstpinname="Input">
    </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="117" systemname="IOBox (String)">
-   <BOUNDS type="Box" left="3178" top="4242" width="945" height="805">
+   <BOUNDS type="Box" left="1468" top="2442" width="975" height="2190">
    </BOUNDS>
-   <BOUNDS type="Node" left="3178" top="4242" width="0" height="0">
+   <BOUNDS type="Node" left="1468" top="2442" width="0" height="0">
    </BOUNDS>
-   <PIN pinname="Input String" slicecount="5" visible="1" values="Cons,Group,Zip,Input,InputMorph">
+   <PIN pinname="Input String" slicecount="11" visible="1" values="Cons,Group,Zip,Input,InputMorph,UnZip,OR,AND,+,-,*">
    </PIN>
    <PIN pinname="Default" slicecount="1" values="text">
    </PIN>
@@ -307,7 +307,7 @@
    </PIN>
    <PIN pinname="Maximum Characters" slicecount="1" values="-1">
    </PIN>
-   <PIN pinname="Rows" slicecount="1" values="5">
+   <PIN pinname="Rows" slicecount="1" values="11">
    </PIN>
    <PIN pinname="SliceCount Mode" slicecount="1" values="ColsRowsPages">
    </PIN>
@@ -430,4 +430,6 @@
    </LINK>
    <LINK srcnodeid="126" srcpinname="Y Output Value" dstnodeid="16" dstpinname="Enabled">
    </LINK>
+   <PACK Name="vvvv-Message" Version="2.9.8">
+   </PACK>
    </PATCH>

--- a/modules/Common/ChangePatch (VVVV XElement).v4p
+++ b/modules/Common/ChangePatch (VVVV XElement).v4p
@@ -1,8 +1,8 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta34.1.dtd" >
-   <PATCH nodename="C:\dev\vvvv\vvvv-Patchbox\modules\Common\ChangePatch (VVVV XElement).v4p" systemname="ChangePatch" filename="C:\dev\vvvv\vvvv-Patchbox\modules\Common\ChangePatch.v4p" scrollx="0" scrolly="3210">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50alpha35.5.dtd" >
+   <PATCH nodename="C:\dev\vvvv\vvvv-Patchbox\modules\Common\ChangePatch (VVVV XElement).v4p" systemname="ChangePatch" filename="C:\dev\vvvv\vvvv-Patchbox\modules\Common\ChangePatch.v4p" scrollx="0" scrolly="0">
    <BOUNDS type="Window" left="16392" top="3684" width="8316" height="7452">
    </BOUNDS>
-   <PACK Name="addonpack" Version="34.1.0">
+   <PACK Name="addonpack" Version="35.0.0">
    </PACK>
    <NODE systemname="SetPatch (VVVV)" nodename="SetPatch (VVVV)" componentmode="Hidden" id="1">
    <BOUNDS type="Node" left="2103" top="4596" width="4740" height="276">
@@ -222,4 +222,6 @@
    </LINK>
    <LINK srcnodeid="15" srcpinname="Output" dstnodeid="1" dstpinname="XML Input">
    </LINK>
+   <PACK Name="vvvv-Message" Version="2.9.8">
+   </PACK>
    </PATCH>

--- a/modules/ShowV4Folders (VVVV).v4p
+++ b/modules/ShowV4Folders (VVVV).v4p
@@ -1,0 +1,7 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.5.dtd" >
+   <PATCH nodename="D:\Documents\dev\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p" systemname="ShowV4Folders (VVVV)" filename="D:\Documents\dev\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p">
+   <BOUNDS type="Window" left="12418" top="8666" width="9000" height="6000">
+   </BOUNDS>
+   <PACK Name="addonpack" Version="35.0.0">
+   </PACK>
+   </PATCH>

--- a/modules/ShowV4Folders (VVVV).v4p
+++ b/modules/ShowV4Folders (VVVV).v4p
@@ -1,175 +1,89 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.5.dtd" >
-   <PATCH nodename="D:\Documents\dev\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p" systemname="ShowV4Folders (VVVV)" filename="D:\Documents\dev\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p" scrollx="0" scrolly="-360">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50alpha35.5.dtd" >
+   <PATCH nodename="C:\dev\vvvv\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p" systemname="ShowV4Folders (VVVV)" filename="D:\Documents\dev\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p" scrollx="0" scrolly="0">
    <BOUNDS type="Window" left="2758" top="2625" width="8995" height="7280">
    </BOUNDS>
    <PACK Name="addonpack" Version="35.0.0">
    </PACK>
    <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="73">
-   <BOUNDS type="Node" left="3696" top="1246" width="100" height="100">
+   <BOUNDS type="Node" left="3696" top="796" width="100" height="100">
    </BOUNDS>
-   <BOUNDS type="Box" left="3696" top="1246" width="795" height="240">
+   <BOUNDS type="Box" left="3696" top="796" width="795" height="240">
    </BOUNDS>
    <PIN pinname="Descriptive Name" slicecount="1" values="Patch">
    </PIN>
    <PIN pinname="Output Node" visible="1">
    </PIN>
+   <BOUNDS>
+   </BOUNDS>
    </NODE>
    <NODE systemname="PatchState (VVVV)" nodename="PatchState (VVVV)" componentmode="Hidden" id="72">
-   <BOUNDS type="Node" left="3696" top="1876" width="100" height="100">
+   <BOUNDS type="Node" left="3690" top="1425" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Patch" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Path" visible="1">
    </PIN>
+   <BOUNDS>
+   </BOUNDS>
    </NODE>
    <LINK srcnodeid="73" srcpinname="Output Node" dstnodeid="72" dstpinname="Patch">
    </LINK>
    <NODE systemname="FileName (File Split)" nodename="FileName (File Split)" componentmode="Hidden" id="70">
-   <BOUNDS type="Node" left="3857" top="2926" width="100" height="100">
+   <BOUNDS type="Node" left="3855" top="1875" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Filename" visible="1">
    </PIN>
    <PIN pinname="Path" visible="1">
    </PIN>
+   <BOUNDS>
+   </BOUNDS>
    </NODE>
    <LINK srcnodeid="72" srcpinname="Path" dstnodeid="70" dstpinname="Filename">
    </LINK>
    <NODE systemname="Keyboard (Devices Desktop)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Keyboard (Devices Desktop)" componentmode="Hidden" id="69">
-   <BOUNDS type="Node" left="6237" top="1876" width="100" height="100">
+   <BOUNDS type="Node" left="6240" top="1425" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Device" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="6237" top="1876">
+   <BOUNDS type="Box" left="6240" top="1425">
    </BOUNDS>
    <PIN pinname="Enabled" visible="1">
    </PIN>
    </NODE>
-   <NODE systemname="KeyMatch (Keyboard)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="KeyMatch (Keyboard)" componentmode="Hidden" id="68">
-   <BOUNDS type="Node" left="6235" top="2422" width="1635" height="270">
-   </BOUNDS>
-   <PIN pinname="Keyboard" visible="1">
-   </PIN>
-   <PIN pinname="Key Match" slicecount="1" values="|ShiftKey, Menu, R, V|">
-   </PIN>
-   <PIN pinname="ControlKey" visible="1">
-   </PIN>
-   <PIN pinname="Menu" visible="1">
-   </PIN>
-   <PIN pinname="R" visible="1">
-   </PIN>
-   <BOUNDS type="Box" left="6235" top="2422">
-   </BOUNDS>
-   <PIN pinname="V" visible="1">
-   </PIN>
-   <PIN pinname="ShiftKey" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="69" srcpinname="Device" dstnodeid="68" dstpinname="Keyboard">
-   </LINK>
    <NODE systemname="AND (Boolean)" nodename="AND (Boolean)" componentmode="Hidden" id="67">
-   <BOUNDS type="Node" left="6237" top="2926" width="780" height="270">
+   <BOUNDS type="Node" left="6222" top="3751" width="1305" height="270">
    </BOUNDS>
-   <PIN pinname="Input Count" slicecount="1" values="3">
+   <PIN pinname="Input Count" slicecount="1" values="2">
    </PIN>
    <PIN pinname="Input 1" visible="1" slicecount="1" values="0">
    </PIN>
-   <PIN pinname="Input 2" visible="1">
+   <PIN pinname="Input 2" visible="1" slicecount="1" values="0">
    </PIN>
-   <PIN pinname="Input 3" visible="1">
+   <PIN pinname="Input 3" visible="1" slicecount="1" values="1">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="||">
+   </PIN>
    </NODE>
-   <LINK srcnodeid="68" srcpinname="Menu" dstnodeid="67" dstpinname="Input 2" linkstyle="VHV">
-   <LINKPOINT x="6745" y="2775">
-   </LINKPOINT>
-   <LINKPOINT x="6655" y="2775">
-   </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="68" srcpinname="R" dstnodeid="67" dstpinname="Input 3" linkstyle="VHV">
-   <LINKPOINT x="7285" y="2775">
-   </LINKPOINT>
-   <LINKPOINT x="7015" y="2775">
-   </LINKPOINT>
-   </LINK>
    <NODE systemname="TogEdge (Animation)" nodename="TogEdge (Animation)" componentmode="Hidden" id="66">
-   <BOUNDS type="Node" left="6244" top="4585" width="100" height="100">
+   <BOUNDS type="Node" left="6244" top="4885" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1" slicecount="1" values="0">
    </PIN>
    <PIN pinname="Up Edge" visible="1">
    </PIN>
    </NODE>
-   <NODE systemname="AND (Boolean)" nodename="AND (Boolean)" componentmode="Hidden" id="65">
-   <BOUNDS type="Node" left="7091" top="2926" width="780" height="270">
-   </BOUNDS>
-   <PIN pinname="Input Count" slicecount="1" values="3">
-   </PIN>
-   <PIN pinname="Input 1" visible="1" slicecount="1" values="0">
-   </PIN>
-   <PIN pinname="Input 2" visible="1">
-   </PIN>
-   <PIN pinname="Input 3" visible="1" slicecount="1" values="0">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="68" srcpinname="Menu" dstnodeid="65" dstpinname="Input 2" linkstyle="VHV">
-   <LINKPOINT x="6820" y="2775">
-   </LINKPOINT>
-   <LINKPOINT x="7450" y="2775">
-   </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="68" srcpinname="V" dstnodeid="65" dstpinname="Input 3" linkstyle="VHV">
-   <LINKPOINT x="7343" y="2786">
-   </LINKPOINT>
-   <LINKPOINT x="7812" y="2786">
-   </LINKPOINT>
-   </LINK>
-   <NODE systemname="Cons (Spreads)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Cons (Spreads)" componentmode="Hidden" id="64">
-   <BOUNDS type="Node" left="6244" top="3395" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Input 1" visible="1">
-   </PIN>
-   <PIN pinname="Input 2" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   <BOUNDS type="Box" left="6244" top="3395">
-   </BOUNDS>
-   </NODE>
-   <LINK srcnodeid="67" srcpinname="Output" dstnodeid="64" dstpinname="Input 1">
-   </LINK>
-   <LINK srcnodeid="65" srcpinname="Output" dstnodeid="64" dstpinname="Input 2" linkstyle="Bezier">
-   <LINKPOINT x="7088" y="3262">
-   </LINKPOINT>
-   <LINKPOINT x="6740" y="3262">
-   </LINKPOINT>
-   </LINK>
-   <NODE systemname="Sift (Value)" nodename="Sift (Value)" componentmode="Hidden" id="62">
-   <BOUNDS type="Node" left="4224" top="4042" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Filter" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Input" visible="1">
-   </PIN>
-   <PIN pinname="Input Index" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="64" srcpinname="Output" dstnodeid="62" dstpinname="Input" linkstyle="VHV">
-   <LINKPOINT x="6249" y="3804">
-   </LINKPOINT>
-   <LINKPOINT x="4278" y="3876">
-   </LINKPOINT>
-   </LINK>
    <NODE systemname="SystemFolder (File)" nodename="SystemFolder (File)" componentmode="Hidden" id="61">
-   <BOUNDS type="Node" left="4718" top="2926" width="100" height="100">
+   <BOUNDS type="Node" left="4725" top="1875" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Output" visible="1">
    </PIN>
+   <BOUNDS>
+   </BOUNDS>
    </NODE>
    <NODE systemname="Cons (String)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Cons (String)" componentmode="Hidden" id="60">
-   <BOUNDS type="Node" left="3864" top="3395" width="900" height="270">
+   <BOUNDS type="Node" left="3870" top="2340" width="900" height="270">
    </BOUNDS>
    <PIN pinname="Input 1" visible="1">
    </PIN>
@@ -177,43 +91,29 @@
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="3864" top="3395">
+   <BOUNDS type="Box" left="3870" top="2340">
+   </BOUNDS>
+   <PIN pinname="Output Bin Size" visible="1">
+   </PIN>
+   <BOUNDS>
    </BOUNDS>
    </NODE>
    <LINK srcnodeid="70" srcpinname="Path" dstnodeid="60" dstpinname="Input 1">
    </LINK>
    <LINK srcnodeid="61" srcpinname="Output" dstnodeid="60" dstpinname="Input 2">
    </LINK>
-   <NODE systemname="GetSlice (String)" nodename="GetSlice (String)" componentmode="Hidden" id="59">
-   <BOUNDS type="Node" left="3872" top="4432" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Input" visible="1">
-   </PIN>
-   <PIN pinname="Index" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="60" srcpinname="Output" dstnodeid="59" dstpinname="Input">
-   </LINK>
-   <LINK srcnodeid="62" srcpinname="Input Index" dstnodeid="59" dstpinname="Index">
-   </LINK>
    <NODE systemname="OpenExplorer (Windows)" filename="Windows\OpenExplorer (Windows).v4p" nodename="OpenExplorer (Windows)" componentmode="Hidden" id="71">
-   <BOUNDS type="Node" left="5068" top="5572" width="100" height="100">
+   <BOUNDS type="Node" left="5068" top="5572" width="1245" height="270">
    </BOUNDS>
    <PIN pinname="Path" visible="1">
    </PIN>
    <PIN pinname="Open" visible="1" slicecount="1" values="0">
    </PIN>
+   <BOUNDS type="Window" left="13635" top="4710" width="4725" height="4275">
+   </BOUNDS>
    </NODE>
-   <LINK srcnodeid="59" srcpinname="Output" dstnodeid="71" dstpinname="Path" linkstyle="Bezier">
-   <LINKPOINT x="3927" y="5076">
-   </LINKPOINT>
-   <LINKPOINT x="5068" y="5172">
-   </LINKPOINT>
-   </LINK>
    <NODE systemname="Change (Animation Spectral)" filename="%VVVV%\lib\nodes\modules\Animation\Change (Animation Spectral).v4p" nodename="Change (Animation Spectral)" componentmode="Hidden" id="63">
-   <BOUNDS type="Node" left="6244" top="4088" width="100" height="100">
+   <BOUNDS type="Node" left="6240" top="4395" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -221,15 +121,15 @@
    </PIN>
    <PIN pinname="OnChange" visible="1">
    </PIN>
+   <BOUNDS type="Box" left="6240" top="4395">
+   </BOUNDS>
    </NODE>
-   <LINK srcnodeid="64" srcpinname="Output" dstnodeid="63" dstpinname="Input">
-   </LINK>
    <LINK srcnodeid="63" srcpinname="OnChange" dstnodeid="66" dstpinname="Input">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="74" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="6244" top="1246" width="462" height="224">
+   <BOUNDS type="Box" left="6244" top="796" width="462" height="224">
    </BOUNDS>
-   <BOUNDS type="Node" left="6244" top="1246" width="0" height="0">
+   <BOUNDS type="Node" left="6244" top="796" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -246,56 +146,12 @@
    </NODE>
    <LINK srcnodeid="74" srcpinname="Y Output Value" dstnodeid="69" dstpinname="Enabled">
    </LINK>
-   <NODE systemname="IsActive (VVVV)" filename="%VVVV%\lib\nodes\modules\VVVV\IsActive (VVVV).v4p" nodename="IsActive (VVVV)" componentmode="Hidden" id="75">
-   <BOUNDS type="Node" left="7056" top="4585" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Enabled" slicecount="1" values="1">
-   </PIN>
-   <BOUNDS type="Window" left="11963" top="6335" width="4466" height="4949">
-   </BOUNDS>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   <BOUNDS type="Box" left="7056" top="4585">
-   </BOUNDS>
-   </NODE>
-   <NODE systemname="AND (Boolean)" nodename="AND (Boolean)" componentmode="Hidden" id="76">
-   <BOUNDS type="Node" left="6237" top="5131" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Input 1" visible="1">
-   </PIN>
-   <PIN pinname="Input 2" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="66" srcpinname="Up Edge" dstnodeid="76" dstpinname="Input 1">
-   </LINK>
-   <LINK srcnodeid="75" srcpinname="Output" dstnodeid="76" dstpinname="Input 2" linkstyle="Bezier">
-   <LINKPOINT x="7056" y="4984">
-   </LINKPOINT>
-   <LINKPOINT x="6664" y="4984">
-   </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="76" srcpinname="Output" dstnodeid="71" dstpinname="Open">
-   </LINK>
-   <LINK srcnodeid="68" srcpinname="ShiftKey" dstnodeid="65" dstpinname="Input 1" linkstyle="VHV">
-   <LINKPOINT x="7812" y="2786">
-   </LINKPOINT>
-   <LINKPOINT x="7147" y="2786">
-   </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="68" srcpinname="ShiftKey" dstnodeid="67" dstpinname="Input 1" linkstyle="VHV">
-   <LINKPOINT x="7812" y="2786">
-   </LINKPOINT>
-   <LINKPOINT x="6293" y="2786">
-   </LINKPOINT>
-   </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="108" systemname="IOBox (String)">
-   <BOUNDS type="Node" left="280" top="800" width="1275" height="270">
+   <BOUNDS type="Node" left="275" top="805" width="1275" height="270">
    </BOUNDS>
-   <BOUNDS type="Box" left="280" top="800" width="2548" height="1589">
+   <BOUNDS type="Box" left="275" top="805" width="2655" height="2310">
    </BOUNDS>
-   <PIN pinname="Input String" visible="0" slicecount="1" values="|v.1.0 by sebescudie&cr;&lf;&cr;&lf;Quickly opens vvvv folders with a shortcut :&cr;&lf;&cr;&lf;- ALT + SHIFT + V opens currently running VVVV folder&cr;&lf;- ALT + SHIFT + R opens the folder the current patch sits in|">
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|v.1.0 by sebescudie&cr;&lf;v 1.1 by velcrome&cr;&lf;&cr;&lf;Quickly opens vvvv folders with a shortcut :&cr;&lf;&cr;&lf;- ALT + F3 opens currently running VVVV folder&cr;&lf;- F3 opens the folder the current patch sits in|">
    </PIN>
    <PIN pinname="Output String" visible="0">
    </PIN>
@@ -322,4 +178,162 @@
    <PIN pinname="Size" slicecount="1" values="15">
    </PIN>
    </NODE>
+   <NODE systemname="Select (String)" nodename="Select (String)" componentmode="Hidden" id="59">
+   <BOUNDS type="Node" left="3870" top="4395" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Index" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Select" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="60" srcpinname="Output" dstnodeid="59" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="59" srcpinname="Output" dstnodeid="71" dstpinname="Path" linkstyle="Bezier">
+   <LINKPOINT x="3927" y="5076">
+   </LINKPOINT>
+   <LINKPOINT x="5068" y="5172">
+   </LINKPOINT>
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="110" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="7260" top="4395" width="285" height="675">
+   </BOUNDS>
+   <BOUNDS type="Node" left="7260" top="4395" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Y Input Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="67" srcpinname="Output" dstnodeid="110" dstpinname="Y Input Value" linkstyle="Bezier">
+   <LINKPOINT x="6285" y="4193">
+   </LINKPOINT>
+   <LINKPOINT x="7260" y="4193">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="67" srcpinname="Output" dstnodeid="59" dstpinname="Select" linkstyle="Bezier">
+   <LINKPOINT x="6225" y="4193">
+   </LINKPOINT>
+   <LINKPOINT x="4410" y="4193">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="67" srcpinname="Output" dstnodeid="63" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="66" srcpinname="Up Edge" dstnodeid="71" dstpinname="Open">
+   </LINK>
+   <PACK Name="vvvv-Message" Version="2.9.8">
+   </PACK>
+   <NODE systemname="PeakSpread (Spreads)" nodename="PeakSpread (Spreads)" componentmode="Hidden" id="118">
+   <BOUNDS type="Node" left="7455" top="3255" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Spread Count" slicecount="1" values="2" visible="1">
+   </PIN>
+   <PIN pinname="Input" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Add (Value Spectral)" nodename="Add (Value Spectral)" componentmode="Hidden" id="120" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="4725" top="2655" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS>
+   </BOUNDS>
+   <BOUNDS>
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="60" srcpinname="Output Bin Size" dstnodeid="120" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="120" srcpinname="Output" dstnodeid="118" dstpinname="Spread Count" linkstyle="VHV" hiddenwhenlocked="1">
+   <LINKPOINT x="4785" y="3063">
+   </LINKPOINT>
+   <LINKPOINT x="8310" y="3088">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="KeyMatch (Keyboard)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="KeyMatch (Keyboard)" componentmode="Hidden" id="68">
+   <BOUNDS type="Node" left="6240" top="2340" width="2505" height="270">
+   </BOUNDS>
+   <PIN pinname="Keyboard" visible="1">
+   </PIN>
+   <PIN pinname="Key Match" slicecount="1" values="|F3, Menu, ShiftKey|">
+   </PIN>
+   <PIN pinname="ControlKey" visible="1">
+   </PIN>
+   <PIN pinname="Menu" visible="1">
+   </PIN>
+   <PIN pinname="R" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="6240" top="2340">
+   </BOUNDS>
+   <PIN pinname="V" visible="1">
+   </PIN>
+   <PIN pinname="ShiftKey" visible="1">
+   </PIN>
+   <PIN pinname="F3" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="69" srcpinname="Device" dstnodeid="68" dstpinname="Keyboard">
+   </LINK>
+   <LINK srcnodeid="68" srcpinname="F3" dstnodeid="67" dstpinname="Input 3">
+   </LINK>
+   <LINK srcnodeid="118" srcpinname="Output" dstnodeid="67" dstpinname="Input 2">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="121" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="6225" top="3135" width="315" height="300">
+   </BOUNDS>
+   <BOUNDS type="Node" left="6225" top="3135" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="F3">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="68" srcpinname="F3" dstnodeid="121" dstpinname="Y Input Value">
+   </LINK>
+   <LINK srcnodeid="121" srcpinname="Y Output Value" dstnodeid="67" dstpinname="Input 1">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="122" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="7455" top="2670" width="285" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="7455" top="2670" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Menu">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="68" srcpinname="Menu" dstnodeid="122" dstpinname="Y Input Value">
+   </LINK>
+   <LINK srcnodeid="122" srcpinname="Y Output Value" dstnodeid="118" dstpinname="Input">
+   </LINK>
    </PATCH>

--- a/modules/ShowV4Folders (VVVV).v4p
+++ b/modules/ShowV4Folders (VVVV).v4p
@@ -1,6 +1,6 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50alpha35.5.dtd" >
    <PATCH nodename="C:\dev\vvvv\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p" systemname="ShowV4Folders (VVVV)" filename="D:\Documents\dev\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p" scrollx="0" scrolly="0">
-   <BOUNDS type="Window" left="2758" top="2625" width="8995" height="7280">
+   <BOUNDS type="Window" left="2745" top="2625" width="9615" height="7905">
    </BOUNDS>
    <PACK Name="addonpack" Version="35.0.0">
    </PACK>
@@ -41,17 +41,17 @@
    <LINK srcnodeid="72" srcpinname="Path" dstnodeid="70" dstpinname="Filename">
    </LINK>
    <NODE systemname="Keyboard (Devices Desktop)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Keyboard (Devices Desktop)" componentmode="Hidden" id="69">
-   <BOUNDS type="Node" left="6240" top="1425" width="100" height="100">
+   <BOUNDS type="Node" left="6240" top="1785" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Device" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="6240" top="1425">
+   <BOUNDS type="Box" left="6240" top="1785">
    </BOUNDS>
    <PIN pinname="Enabled" visible="1">
    </PIN>
    </NODE>
    <NODE systemname="AND (Boolean)" nodename="AND (Boolean)" componentmode="Hidden" id="67">
-   <BOUNDS type="Node" left="6222" top="3751" width="1305" height="270">
+   <BOUNDS type="Node" left="6222" top="4651" width="957" height="270">
    </BOUNDS>
    <PIN pinname="Input Count" slicecount="1" values="2">
    </PIN>
@@ -67,7 +67,7 @@
    </PIN>
    </NODE>
    <NODE systemname="TogEdge (Animation)" nodename="TogEdge (Animation)" componentmode="Hidden" id="66">
-   <BOUNDS type="Node" left="6244" top="4885" width="100" height="100">
+   <BOUNDS type="Node" left="6244" top="5785" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1" slicecount="1" values="0">
    </PIN>
@@ -83,7 +83,7 @@
    </BOUNDS>
    </NODE>
    <NODE systemname="Cons (String)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Cons (String)" componentmode="Hidden" id="60">
-   <BOUNDS type="Node" left="3870" top="2340" width="900" height="270">
+   <BOUNDS type="Node" left="3870" top="2340" width="1740" height="270">
    </BOUNDS>
    <PIN pinname="Input 1" visible="1">
    </PIN>
@@ -97,39 +97,21 @@
    </PIN>
    <BOUNDS>
    </BOUNDS>
+   <PIN pinname="Input Count" slicecount="1" values="3">
+   </PIN>
+   <BOUNDS>
+   </BOUNDS>
+   <PIN pinname="Input 3" visible="1">
+   </PIN>
    </NODE>
    <LINK srcnodeid="70" srcpinname="Path" dstnodeid="60" dstpinname="Input 1">
    </LINK>
    <LINK srcnodeid="61" srcpinname="Output" dstnodeid="60" dstpinname="Input 2">
    </LINK>
-   <NODE systemname="OpenExplorer (Windows)" filename="Windows\OpenExplorer (Windows).v4p" nodename="OpenExplorer (Windows)" componentmode="Hidden" id="71">
-   <BOUNDS type="Node" left="5068" top="5572" width="1245" height="270">
-   </BOUNDS>
-   <PIN pinname="Path" visible="1">
-   </PIN>
-   <PIN pinname="Open" visible="1" slicecount="1" values="0">
-   </PIN>
-   <BOUNDS type="Window" left="13635" top="4710" width="4725" height="4275">
-   </BOUNDS>
-   </NODE>
-   <NODE systemname="Change (Animation Spectral)" filename="%VVVV%\lib\nodes\modules\Animation\Change (Animation Spectral).v4p" nodename="Change (Animation Spectral)" componentmode="Hidden" id="63">
-   <BOUNDS type="Node" left="6240" top="4395" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Input" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   <PIN pinname="OnChange" visible="1">
-   </PIN>
-   <BOUNDS type="Box" left="6240" top="4395">
-   </BOUNDS>
-   </NODE>
-   <LINK srcnodeid="63" srcpinname="OnChange" dstnodeid="66" dstpinname="Input">
-   </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="74" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="6244" top="796" width="462" height="224">
+   <BOUNDS type="Box" left="6244" top="856" width="462" height="224">
    </BOUNDS>
-   <BOUNDS type="Node" left="6244" top="796" width="0" height="0">
+   <BOUNDS type="Node" left="6244" top="856" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
@@ -143,9 +125,9 @@
    </PIN>
    <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
    </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
    </NODE>
-   <LINK srcnodeid="74" srcpinname="Y Output Value" dstnodeid="69" dstpinname="Enabled">
-   </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="108" systemname="IOBox (String)">
    <BOUNDS type="Node" left="275" top="805" width="1275" height="270">
    </BOUNDS>
@@ -179,7 +161,7 @@
    </PIN>
    </NODE>
    <NODE systemname="Select (String)" nodename="Select (String)" componentmode="Hidden" id="59">
-   <BOUNDS type="Node" left="3870" top="4395" width="100" height="100">
+   <BOUNDS type="Node" left="3870" top="5295" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -192,16 +174,10 @@
    </NODE>
    <LINK srcnodeid="60" srcpinname="Output" dstnodeid="59" dstpinname="Input">
    </LINK>
-   <LINK srcnodeid="59" srcpinname="Output" dstnodeid="71" dstpinname="Path" linkstyle="Bezier">
-   <LINKPOINT x="3927" y="5076">
-   </LINKPOINT>
-   <LINKPOINT x="5068" y="5172">
-   </LINKPOINT>
-   </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="110" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7260" top="4395" width="285" height="675">
+   <BOUNDS type="Box" left="7260" top="5295" width="285" height="1005">
    </BOUNDS>
-   <BOUNDS type="Node" left="7260" top="4395" width="0" height="0">
+   <BOUNDS type="Node" left="7260" top="5295" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -211,33 +187,29 @@
    </PIN>
    <PIN pinname="Behavior" slicecount="1" values="Toggle">
    </PIN>
-   <PIN pinname="Rows" slicecount="1" values="3">
+   <PIN pinname="Rows" slicecount="1" values="4">
    </PIN>
    <PIN pinname="Y Input Value" visible="1">
    </PIN>
    </NODE>
    <LINK srcnodeid="67" srcpinname="Output" dstnodeid="110" dstpinname="Y Input Value" linkstyle="Bezier">
-   <LINKPOINT x="6285" y="4193">
+   <LINKPOINT x="6285" y="5093">
    </LINKPOINT>
-   <LINKPOINT x="7260" y="4193">
+   <LINKPOINT x="7260" y="5093">
    </LINKPOINT>
    </LINK>
    <LINK srcnodeid="67" srcpinname="Output" dstnodeid="59" dstpinname="Select" linkstyle="Bezier">
-   <LINKPOINT x="6225" y="4193">
+   <LINKPOINT x="6225" y="5093">
    </LINKPOINT>
-   <LINKPOINT x="4410" y="4193">
+   <LINKPOINT x="4410" y="5093">
    </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="67" srcpinname="Output" dstnodeid="63" dstpinname="Input">
-   </LINK>
-   <LINK srcnodeid="66" srcpinname="Up Edge" dstnodeid="71" dstpinname="Open">
    </LINK>
    <PACK Name="vvvv-Message" Version="2.9.8">
    </PACK>
    <NODE systemname="PeakSpread (Spreads)" nodename="PeakSpread (Spreads)" componentmode="Hidden" id="118">
-   <BOUNDS type="Node" left="7455" top="3255" width="100" height="100">
+   <BOUNDS type="Node" left="7110" top="4110" width="100" height="100">
    </BOUNDS>
-   <PIN pinname="Spread Count" slicecount="1" values="2" visible="1">
+   <PIN pinname="Spread Count" slicecount="1" visible="1" values="0">
    </PIN>
    <PIN pinname="Input" visible="1" slicecount="1" values="0">
    </PIN>
@@ -245,7 +217,7 @@
    </PIN>
    </NODE>
    <NODE systemname="Add (Value Spectral)" nodename="Add (Value Spectral)" componentmode="Hidden" id="120" hiddenwhenlocked="1">
-   <BOUNDS type="Node" left="4725" top="2655" width="100" height="100">
+   <BOUNDS type="Node" left="5550" top="2805" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -255,14 +227,12 @@
    </BOUNDS>
    <BOUNDS>
    </BOUNDS>
+   <BOUNDS>
+   </BOUNDS>
+   <BOUNDS>
+   </BOUNDS>
    </NODE>
    <LINK srcnodeid="60" srcpinname="Output Bin Size" dstnodeid="120" dstpinname="Input">
-   </LINK>
-   <LINK srcnodeid="120" srcpinname="Output" dstnodeid="118" dstpinname="Spread Count" linkstyle="VHV" hiddenwhenlocked="1">
-   <LINKPOINT x="4785" y="3063">
-   </LINKPOINT>
-   <LINKPOINT x="8310" y="3088">
-   </LINKPOINT>
    </LINK>
    <NODE systemname="KeyMatch (Keyboard)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="KeyMatch (Keyboard)" componentmode="Hidden" id="68">
    <BOUNDS type="Node" left="6240" top="2340" width="2505" height="270">
@@ -293,9 +263,9 @@
    <LINK srcnodeid="118" srcpinname="Output" dstnodeid="67" dstpinname="Input 2">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="121" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="6225" top="3135" width="315" height="300">
+   <BOUNDS type="Box" left="6225" top="4035" width="315" height="300">
    </BOUNDS>
-   <BOUNDS type="Node" left="6225" top="3135" width="0" height="0">
+   <BOUNDS type="Node" left="6225" top="4035" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -315,9 +285,9 @@
    <LINK srcnodeid="121" srcpinname="Y Output Value" dstnodeid="67" dstpinname="Input 1">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="122" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7455" top="2670" width="285" height="240">
+   <BOUNDS type="Box" left="7830" top="2745" width="285" height="240">
    </BOUNDS>
-   <BOUNDS type="Node" left="7455" top="2670" width="0" height="0">
+   <BOUNDS type="Node" left="7830" top="2745" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -334,6 +304,202 @@
    </NODE>
    <LINK srcnodeid="68" srcpinname="Menu" dstnodeid="122" dstpinname="Y Input Value">
    </LINK>
-   <LINK srcnodeid="122" srcpinname="Y Output Value" dstnodeid="118" dstpinname="Input">
+   <NODE systemname="IsActive (VVVV)" filename="%VVVV%\lib\nodes\modules\VVVV\IsActive (VVVV).v4p" nodename="IsActive (VVVV)" componentmode="Hidden" id="123">
+   <BOUNDS type="Node" left="6240" top="1275" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Enabled" slicecount="1" values="1" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="74" srcpinname="Y Output Value" dstnodeid="123" dstpinname="Enabled">
    </LINK>
+   <LINK srcnodeid="123" srcpinname="Output" dstnodeid="69" dstpinname="Enabled">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="125" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="7200" top="1065" width="1755" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7200" top="1065" width="1680" height="525">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|only when this vvvv.exe has focus|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="126" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="5085" top="7320" width="480" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="5085" top="7320" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Success">
+   </PIN>
+   <PIN pinname="Y Input Value" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="OpenExplorer (Windows)" filename="Windows\OpenExplorer (Windows).v4p" nodename="OpenExplorer (Windows)" componentmode="Hidden" id="71">
+   <BOUNDS type="Node" left="5068" top="6472" width="1245" height="270">
+   </BOUNDS>
+   <PIN pinname="Path" visible="1">
+   </PIN>
+   <PIN pinname="Open" visible="1" slicecount="1" values="0">
+   </PIN>
+   <BOUNDS type="Window" left="13635" top="4710" width="6225" height="5175">
+   </BOUNDS>
+   <PIN pinname="Completed" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="59" srcpinname="Output" dstnodeid="71" dstpinname="Path" linkstyle="Bezier">
+   <LINKPOINT x="3927" y="5976">
+   </LINKPOINT>
+   <LINKPOINT x="5068" y="6072">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="66" srcpinname="Up Edge" dstnodeid="71" dstpinname="Open">
+   </LINK>
+   <NODE systemname="OR (Boolean Spectral)" filename="" nodename="OR (Boolean Spectral)" componentmode="Hidden" id="63">
+   <BOUNDS type="Node" left="6240" top="5295" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="OnChange" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="6240" top="5295">
+   </BOUNDS>
+   <PIN pinname="Bin Size" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="67" srcpinname="Output" dstnodeid="63" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="63" srcpinname="Output" dstnodeid="66" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="120" srcpinname="Output" dstnodeid="63" dstpinname="Bin Size" linkstyle="Bezier" hiddenwhenlocked="1">
+   <LINKPOINT x="5335" y="4045">
+   </LINKPOINT>
+   <LINKPOINT x="6800" y="4295">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="TogEdge (Animation)" nodename="TogEdge (Animation)" componentmode="Hidden" id="127">
+   <BOUNDS type="Node" left="5070" top="6900" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Up Edge" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="71" srcpinname="Completed" dstnodeid="127" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="127" srcpinname="Up Edge" dstnodeid="126" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="128" systemname="IOBox (String)">
+   <BOUNDS type="Box" left="5040" top="495" width="975" height="570">
+   </BOUNDS>
+   <BOUNDS type="Node" left="5040" top="495" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="2" visible="1" values=",">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="Directory">
+   </PIN>
+   <PIN pinname="SliceCount Mode" slicecount="1" values="ColsRowsPages">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Custom Directories|">
+   </PIN>
+   <PIN pinname="Output String" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="128" srcpinname="Output String" dstnodeid="60" dstpinname="Input 3">
+   <LINKPOINT x="5535" y="1365">
+   </LINKPOINT>
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="129" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="8670" top="2760" width="285" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="8670" top="2760" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="ShiftKey">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="68" srcpinname="ShiftKey" dstnodeid="129" dstpinname="Y Input Value">
+   </LINK>
+   <NODE systemname="Radix (Value)" nodename="Radix (Value)" componentmode="Hidden" id="131">
+   <BOUNDS type="Node" left="7095" top="3315" width="1185" height="270">
+   </BOUNDS>
+   <PIN pinname="Input Count" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Output Base" visible="1" pintype="Input" slicecount="1" values="10">
+   </PIN>
+   <PIN pinname="Output 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="122" srcpinname="Y Output Value" dstnodeid="131" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="120" srcpinname="Output" dstnodeid="131" dstpinname="Output Base" linkstyle="Bezier" hiddenwhenlocked="1">
+   <LINKPOINT x="5610" y="3180">
+   </LINKPOINT>
+   <LINKPOINT x="7470" y="3180">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="120" srcpinname="Output" dstnodeid="118" dstpinname="Spread Count" linkstyle="Bezier" hiddenwhenlocked="1">
+   <LINKPOINT x="5610" y="3578">
+   </LINKPOINT>
+   <LINKPOINT x="7965" y="3578">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="131" srcpinname="Output 1" dstnodeid="118" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="129" srcpinname="Y Output Value" dstnodeid="131" dstpinname="Input 2">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="134" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="280" top="3290" width="1275" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="280" top="3290" width="2760" height="1170">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|You can add up to 2 more custom directories, which will be accessible via SHIFT+F3 and ALT+SHIFT+F3|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   </NODE>
    </PATCH>

--- a/modules/ShowV4Folders (VVVV).v4p
+++ b/modules/ShowV4Folders (VVVV).v4p
@@ -1,7 +1,325 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.5.dtd" >
-   <PATCH nodename="D:\Documents\dev\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p" systemname="ShowV4Folders (VVVV)" filename="D:\Documents\dev\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p">
-   <BOUNDS type="Window" left="12418" top="8666" width="9000" height="6000">
+   <PATCH nodename="D:\Documents\dev\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p" systemname="ShowV4Folders (VVVV)" filename="D:\Documents\dev\vvvv-Patchbox\modules\ShowV4Folders (VVVV).v4p" scrollx="0" scrolly="-360">
+   <BOUNDS type="Window" left="2758" top="2625" width="8995" height="7280">
    </BOUNDS>
    <PACK Name="addonpack" Version="35.0.0">
    </PACK>
+   <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="73">
+   <BOUNDS type="Node" left="3696" top="1246" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3696" top="1246" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Patch">
+   </PIN>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="PatchState (VVVV)" nodename="PatchState (VVVV)" componentmode="Hidden" id="72">
+   <BOUNDS type="Node" left="3696" top="1876" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Patch" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Path" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="73" srcpinname="Output Node" dstnodeid="72" dstpinname="Patch">
+   </LINK>
+   <NODE systemname="FileName (File Split)" nodename="FileName (File Split)" componentmode="Hidden" id="70">
+   <BOUNDS type="Node" left="3857" top="2926" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Filename" visible="1">
+   </PIN>
+   <PIN pinname="Path" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="72" srcpinname="Path" dstnodeid="70" dstpinname="Filename">
+   </LINK>
+   <NODE systemname="Keyboard (Devices Desktop)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Keyboard (Devices Desktop)" componentmode="Hidden" id="69">
+   <BOUNDS type="Node" left="6237" top="1876" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Device" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="6237" top="1876">
+   </BOUNDS>
+   <PIN pinname="Enabled" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="KeyMatch (Keyboard)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="KeyMatch (Keyboard)" componentmode="Hidden" id="68">
+   <BOUNDS type="Node" left="6235" top="2422" width="1635" height="270">
+   </BOUNDS>
+   <PIN pinname="Keyboard" visible="1">
+   </PIN>
+   <PIN pinname="Key Match" slicecount="1" values="|ShiftKey, Menu, R, V|">
+   </PIN>
+   <PIN pinname="ControlKey" visible="1">
+   </PIN>
+   <PIN pinname="Menu" visible="1">
+   </PIN>
+   <PIN pinname="R" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="6235" top="2422">
+   </BOUNDS>
+   <PIN pinname="V" visible="1">
+   </PIN>
+   <PIN pinname="ShiftKey" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="69" srcpinname="Device" dstnodeid="68" dstpinname="Keyboard">
+   </LINK>
+   <NODE systemname="AND (Boolean)" nodename="AND (Boolean)" componentmode="Hidden" id="67">
+   <BOUNDS type="Node" left="6237" top="2926" width="780" height="270">
+   </BOUNDS>
+   <PIN pinname="Input Count" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Input 1" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 3" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="68" srcpinname="Menu" dstnodeid="67" dstpinname="Input 2" linkstyle="VHV">
+   <LINKPOINT x="6745" y="2775">
+   </LINKPOINT>
+   <LINKPOINT x="6655" y="2775">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="68" srcpinname="R" dstnodeid="67" dstpinname="Input 3" linkstyle="VHV">
+   <LINKPOINT x="7285" y="2775">
+   </LINKPOINT>
+   <LINKPOINT x="7015" y="2775">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="TogEdge (Animation)" nodename="TogEdge (Animation)" componentmode="Hidden" id="66">
+   <BOUNDS type="Node" left="6244" top="4585" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Up Edge" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="AND (Boolean)" nodename="AND (Boolean)" componentmode="Hidden" id="65">
+   <BOUNDS type="Node" left="7091" top="2926" width="780" height="270">
+   </BOUNDS>
+   <PIN pinname="Input Count" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Input 1" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 3" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="68" srcpinname="Menu" dstnodeid="65" dstpinname="Input 2" linkstyle="VHV">
+   <LINKPOINT x="6820" y="2775">
+   </LINKPOINT>
+   <LINKPOINT x="7450" y="2775">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="68" srcpinname="V" dstnodeid="65" dstpinname="Input 3" linkstyle="VHV">
+   <LINKPOINT x="7343" y="2786">
+   </LINKPOINT>
+   <LINKPOINT x="7812" y="2786">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="Cons (Spreads)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Cons (Spreads)" componentmode="Hidden" id="64">
+   <BOUNDS type="Node" left="6244" top="3395" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="6244" top="3395">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="67" srcpinname="Output" dstnodeid="64" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="65" srcpinname="Output" dstnodeid="64" dstpinname="Input 2" linkstyle="Bezier">
+   <LINKPOINT x="7088" y="3262">
+   </LINKPOINT>
+   <LINKPOINT x="6740" y="3262">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="Sift (Value)" nodename="Sift (Value)" componentmode="Hidden" id="62">
+   <BOUNDS type="Node" left="4224" top="4042" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Filter" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Input Index" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="64" srcpinname="Output" dstnodeid="62" dstpinname="Input" linkstyle="VHV">
+   <LINKPOINT x="6249" y="3804">
+   </LINKPOINT>
+   <LINKPOINT x="4278" y="3876">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="SystemFolder (File)" nodename="SystemFolder (File)" componentmode="Hidden" id="61">
+   <BOUNDS type="Node" left="4718" top="2926" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Cons (String)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Cons (String)" componentmode="Hidden" id="60">
+   <BOUNDS type="Node" left="3864" top="3395" width="900" height="270">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="3864" top="3395">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="70" srcpinname="Path" dstnodeid="60" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="61" srcpinname="Output" dstnodeid="60" dstpinname="Input 2">
+   </LINK>
+   <NODE systemname="GetSlice (String)" nodename="GetSlice (String)" componentmode="Hidden" id="59">
+   <BOUNDS type="Node" left="3872" top="4432" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Index" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="60" srcpinname="Output" dstnodeid="59" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="62" srcpinname="Input Index" dstnodeid="59" dstpinname="Index">
+   </LINK>
+   <NODE systemname="OpenExplorer (Windows)" filename="Windows\OpenExplorer (Windows).v4p" nodename="OpenExplorer (Windows)" componentmode="Hidden" id="71">
+   <BOUNDS type="Node" left="5068" top="5572" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Path" visible="1">
+   </PIN>
+   <PIN pinname="Open" visible="1" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="59" srcpinname="Output" dstnodeid="71" dstpinname="Path" linkstyle="Bezier">
+   <LINKPOINT x="3927" y="5076">
+   </LINKPOINT>
+   <LINKPOINT x="5068" y="5172">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="Change (Animation Spectral)" filename="%VVVV%\lib\nodes\modules\Animation\Change (Animation Spectral).v4p" nodename="Change (Animation Spectral)" componentmode="Hidden" id="63">
+   <BOUNDS type="Node" left="6244" top="4088" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="OnChange" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="64" srcpinname="Output" dstnodeid="63" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="63" srcpinname="OnChange" dstnodeid="66" dstpinname="Input">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="74" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="6244" top="1246" width="462" height="224">
+   </BOUNDS>
+   <BOUNDS type="Node" left="6244" top="1246" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="74" srcpinname="Y Output Value" dstnodeid="69" dstpinname="Enabled">
+   </LINK>
+   <NODE systemname="IsActive (VVVV)" filename="%VVVV%\lib\nodes\modules\VVVV\IsActive (VVVV).v4p" nodename="IsActive (VVVV)" componentmode="Hidden" id="75">
+   <BOUNDS type="Node" left="7056" top="4585" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Enabled" slicecount="1" values="1">
+   </PIN>
+   <BOUNDS type="Window" left="11963" top="6335" width="4466" height="4949">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="7056" top="4585">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="AND (Boolean)" nodename="AND (Boolean)" componentmode="Hidden" id="76">
+   <BOUNDS type="Node" left="6237" top="5131" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="66" srcpinname="Up Edge" dstnodeid="76" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="75" srcpinname="Output" dstnodeid="76" dstpinname="Input 2" linkstyle="Bezier">
+   <LINKPOINT x="7056" y="4984">
+   </LINKPOINT>
+   <LINKPOINT x="6664" y="4984">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="76" srcpinname="Output" dstnodeid="71" dstpinname="Open">
+   </LINK>
+   <LINK srcnodeid="68" srcpinname="ShiftKey" dstnodeid="65" dstpinname="Input 1" linkstyle="VHV">
+   <LINKPOINT x="7812" y="2786">
+   </LINKPOINT>
+   <LINKPOINT x="7147" y="2786">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="68" srcpinname="ShiftKey" dstnodeid="67" dstpinname="Input 1" linkstyle="VHV">
+   <LINKPOINT x="7812" y="2786">
+   </LINKPOINT>
+   <LINKPOINT x="6293" y="2786">
+   </LINKPOINT>
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="108" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="280" top="800" width="1275" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="280" top="800" width="2548" height="1589">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|v.1.0 by sebescudie&cr;&lf;&cr;&lf;Quickly opens vvvv folders with a shortcut :&cr;&lf;&cr;&lf;- ALT + SHIFT + V opens currently running VVVV folder&cr;&lf;- ALT + SHIFT + R opens the folder the current patch sits in|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="107" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="280" top="350" width="1275" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="280" top="350" width="2289" height="427">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="ShowV4Folders">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="15">
+   </PIN>
+   </NODE>
    </PATCH>

--- a/modules/Windows/OpenExplorer (Windows).v4p
+++ b/modules/Windows/OpenExplorer (Windows).v4p
@@ -1,0 +1,73 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.5.dtd" >
+   <PATCH nodename="C:\Users\seb\Google Drive\vvvv\patches\tests\openfolder_vanilla\modules\OpenExplorer (Windows).v4p" systemname="OpenExplorer (Windows)" filename="C:\Users\seb\Google Drive\vvvv\patches\tests\openfolder_vanilla\modules\OpenExplorer (Windows).v4p" scrollx="0" scrolly="0">
+   <BOUNDS type="Window" left="13636" top="4711" width="2800" height="2856">
+   </BOUNDS>
+   <PACK Name="addonpack" Version="35.0.0">
+   </PACK>
+   <NODE systemname="ShellExecute (Windows Advanced)" filename="%VVVV%\addonpack\lib\nodes\plugins\ShellExecute.dll" nodename="ShellExecute (Windows Advanced)" componentmode="Hidden" id="18">
+   <BOUNDS type="Node" left="336" top="1806" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Commandline Arguments" visible="1">
+   </PIN>
+   <PIN pinname="Execute" visible="1">
+   </PIN>
+   <PIN pinname="File" visible="1" slicecount="1" values="C:\Windows\system32\cmd.exe">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="17" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="1701" top="378" width="480" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="1701" top="378" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Open">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Y Output Value" dstnodeid="18" dstpinname="Execute">
+   </LINK>
+   <NODE systemname="Add (String)" nodename="Add (String)" componentmode="Hidden" id="16">
+   <BOUNDS type="Node" left="511" top="1148" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 1" slicecount="1" values="|/c explorer|">
+   </PIN>
+   <PIN pinname="Input 2" visible="1" slicecount="1" values="|&quot;C:\Users\seb\Google Drive\vvvv\installs\vvvv_50beta35.5_x64\&quot;|">
+   </PIN>
+   <PIN pinname="Intersperse" slicecount="1" values="Space">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="16" srcpinname="Output" dstnodeid="18" dstpinname="Commandline Arguments">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="14" systemname="IOBox (String)">
+   <BOUNDS type="Box" left="672" top="539" width="693" height="210">
+   </BOUNDS>
+   <BOUNDS type="Node" left="672" top="539" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="1" values="text">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Path">
+   </PIN>
+   <PIN pinname="Output String" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="14" srcpinname="Output String" dstnodeid="16" dstpinname="Input 2">
+   </LINK>
+   </PATCH>

--- a/modules/Windows/OpenExplorer (Windows).v4p
+++ b/modules/Windows/OpenExplorer (Windows).v4p
@@ -1,11 +1,11 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.5.dtd" >
-   <PATCH nodename="C:\Users\seb\Google Drive\vvvv\patches\tests\openfolder_vanilla\modules\OpenExplorer (Windows).v4p" systemname="OpenExplorer (Windows)" filename="C:\Users\seb\Google Drive\vvvv\patches\tests\openfolder_vanilla\modules\OpenExplorer (Windows).v4p" scrollx="0" scrolly="0">
-   <BOUNDS type="Window" left="13636" top="4711" width="2800" height="2856">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50alpha35.5.dtd" >
+   <PATCH nodename="C:\dev\vvvv\vvvv-Patchbox\modules\Windows\OpenExplorer (Windows).v4p" systemname="OpenExplorer (Windows)" filename="C:\Users\seb\Google Drive\vvvv\patches\tests\openfolder_vanilla\modules\OpenExplorer (Windows).v4p" scrollx="0" scrolly="0">
+   <BOUNDS type="Window" left="13635" top="4710" width="6225" height="5175">
    </BOUNDS>
    <PACK Name="addonpack" Version="35.0.0">
    </PACK>
    <NODE systemname="ShellExecute (Windows Advanced)" filename="%VVVV%\addonpack\lib\nodes\plugins\ShellExecute.dll" nodename="ShellExecute (Windows Advanced)" componentmode="Hidden" id="18">
-   <BOUNDS type="Node" left="336" top="1806" width="100" height="100">
+   <BOUNDS type="Node" left="1155" top="1785" width="4035" height="270">
    </BOUNDS>
    <PIN pinname="Commandline Arguments" visible="1">
    </PIN>
@@ -13,11 +13,23 @@
    </PIN>
    <PIN pinname="File" visible="1" slicecount="1" values="C:\Windows\system32\cmd.exe">
    </PIN>
+   <PIN pinname="Completed" visible="1">
+   </PIN>
+   <PIN pinname="Block until finished" visible="1">
+   </PIN>
+   <PIN pinname="Kill" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Show Window" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="1155" top="1785">
+   </BOUNDS>
+   <PIN pinname="Result" visible="1">
+   </PIN>
    </NODE>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="17" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="1701" top="378" width="480" height="480">
+   <BOUNDS type="Box" left="5115" top="435" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="1701" top="378" width="0" height="0">
+   <BOUNDS type="Node" left="5115" top="435" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
    </PIN>
@@ -37,7 +49,7 @@
    <LINK srcnodeid="17" srcpinname="Y Output Value" dstnodeid="18" dstpinname="Execute">
    </LINK>
    <NODE systemname="Add (String)" nodename="Add (String)" componentmode="Hidden" id="16">
-   <BOUNDS type="Node" left="511" top="1148" width="100" height="100">
+   <BOUNDS type="Node" left="1921" top="863" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input 1" slicecount="1" values="|/c explorer|">
    </PIN>
@@ -51,9 +63,9 @@
    <LINK srcnodeid="16" srcpinname="Output" dstnodeid="18" dstpinname="Commandline Arguments">
    </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="14" systemname="IOBox (String)">
-   <BOUNDS type="Box" left="672" top="539" width="693" height="210">
+   <BOUNDS type="Box" left="2100" top="435" width="693" height="210">
    </BOUNDS>
-   <BOUNDS type="Node" left="672" top="539" width="0" height="0">
+   <BOUNDS type="Node" left="2100" top="435" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Input String" slicecount="1" visible="1" values="text">
    </PIN>
@@ -69,5 +81,99 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="14" srcpinname="Output String" dstnodeid="16" dstpinname="Input 2">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="19" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="5115" top="2205" width="480" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="5115" top="2205" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Completed">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="18" srcpinname="Completed" dstnodeid="19" dstpinname="Y Input Value">
+   </LINK>
+   <PACK Name="vvvv-Message" Version="2.9.8">
+   </PACK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="20" systemname="IOBox (String)">
+   <BOUNDS type="Box" left="1155" top="1200" width="3060" height="270">
+   </BOUNDS>
+   <BOUNDS type="Node" left="1155" top="1200" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="1" values="C:\Windows\system32\cmd.exe">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="C:\Windows\system32\cmd.exe">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="|All Files (*.*)||*.*|">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="Filename">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="20" srcpinname="Output String" dstnodeid="18" dstpinname="File">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="21" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="3555" top="525" width="480" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="3555" top="525" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Block until finished|">
+   </PIN>
+   <PIN pinname="Pin Visibility" slicecount="1" values="Hidden">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="21" srcpinname="Y Output Value" dstnodeid="18" dstpinname="Block until finished">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="22" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="2745" top="1485" width="285" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="2745" top="1485" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="22" srcpinname="Y Output Value" dstnodeid="18" dstpinname="Show Window">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="23" systemname="IOBox (String)">
+   <BOUNDS type="Box" left="1185" top="2325" width="2490" height="1290">
+   </BOUNDS>
+   <BOUNDS type="Node" left="1185" top="2325" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Default" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="18" srcpinname="Result" dstnodeid="23" dstpinname="Input String">
    </LINK>
    </PATCH>


### PR DESCRIPTION
Added a feature that allows to open vvvv related folders with a shortcut :

- SHIFT + ALT + V opens the running vvvv folder
- SHIFT + ALT + R opens the folder the active patch sits in